### PR TITLE
Pid control

### DIFF
--- a/pid_control/docs/docs_computer_vision_module.md
+++ b/pid_control/docs/docs_computer_vision_module.md
@@ -159,41 +159,41 @@ It draws:
 graph TD
     %% ===== TOP-LEVEL PIPELINE =====
     subgraph Pipeline ["Vision pipeline"]
-        A["Binary mask (128×128)"] --> B["extractLanePoints"]
+        A["Binary mask (128x128)"] --> B["extractLanePoints"]
         B -->|"lanes detected"| C["calculateTrackCenter"]
         B -->|"no lane"| Z["Return -1"]
-        C --> D["draw_overlay (optional)"]
+        C --> D["optional: draw_overlay"]
         C --> E["center X plus y_ref"]
     end
 
     %% ===== extractLanePoints DETAILS =====
     subgraph B_details ["Inside extractLanePoints()"]
-        B1["Loop ROIs (rows 3 … 6)"] --> B2["findContours"]
-        B2 --> B3{"contour.size() ≥ 5 ?"}
+        B1["Loop ROIs (rows 3 to 6)"] --> B2["findContours"]
+        B2 --> B3{"contour.size() >= 5?"}
         B3 -- no  --> B1
         B3 -- yes --> B4["fitLine(contour)"]
-        B4 --> B5["slope & distance → classify left or right"]
-        B5 --> B6{"better than previous ?"}
+        B4 --> B5["slope & distance -> classify as left or right"]
+        B5 --> B6{"better than previous?"}
         B6 -- no  --> B1
         B6 -- yes --> B7["store center_left and center_right"]
         B7 --> B1
-        B1 --> B8{"found at least one lane ?"}
+        B1 --> B8{"found at least one lane?"}
         B8 -- no  --> Z
-        B8 -- yes --> B9["return left / right points and y_ref"]
+        B8 -- yes --> B9["return left and right points and y_ref"]
     end
 
     %% ===== calculateTrackCenter DETAILS =====
     subgraph C_details ["Inside calculateTrackCenter()"]
-        C1{"both lanes present ?"}
+        C1{"both lanes present?"}
         C1 -- yes        --> C2["fitLine(left) and fitLine(right)"]
         C2 --> C3["x_left and x_right at y_ref"]
-        C3 --> C7["center = (xL + xR) / 2"]
-        C1 -- only right --> C4["x_right at y_ref"]
-        C4 --> C5["center = xR minus disp_cm / scale"]
-        C1 -- only left  --> C6["x_left at y_ref"]
-        C6 --> C5
-        C5 --> C7
-        C7 --> C8["draw circles"]
+        C3 --> C4["center = (xL + xR) / 2"]
+        C1 -- only right --> C5["x_right at y_ref"]
+        C5 --> C6["center = xR - (disp_cm / scale)"]
+        C1 -- only left  --> C7["x_left at y_ref"]
+        C7 --> C6
+        C6 --> C4
+        C4 --> C8["draw circles"]
         C8 --> E
     end
 ```

--- a/pid_control/docs/docs_computer_vision_module.md
+++ b/pid_control/docs/docs_computer_vision_module.md
@@ -158,42 +158,42 @@ It draws:
 ```mermaid
 graph TD
     %% ===== TOP-LEVEL PIPELINE =====
-    subgraph Pipeline  [Vision pipeline]
+    subgraph Pipeline ["Vision pipeline"]
         A["Binary mask (128×128)"] --> B["extractLanePoints"]
         B -->|"lanes detected"| C["calculateTrackCenter"]
-        B -->|"no lane"| Z["Return −1"]
+        B -->|"no lane"| Z["Return -1"]
         C --> D["draw_overlay (optional)"]
-        C --> E["centre X + y_ref"]
+        C --> E["center X plus y_ref"]
     end
 
-    %% ====== extractLanePoints DETAILS ======
-    subgraph B_details  ["Inside extractLanePoints()"]
-        B1["Loop ROIs (row 3 … 6)"] --> B2["findContours"]
-        B2 --> B3{"contour.size() ≥ 5?"}
-        B3 -- no --> B1
+    %% ===== extractLanePoints DETAILS =====
+    subgraph B_details ["Inside extractLanePoints()"]
+        B1["Loop ROIs (rows 3 … 6)"] --> B2["findContours"]
+        B2 --> B3{"contour.size() ≥ 5 ?"}
+        B3 -- no  --> B1
         B3 -- yes --> B4["fitLine(contour)"]
-        B4 --> B5["slope & distance ↦ classify • left / right"]
-        B5 --> B6{"better than previous?"}
-        B6 -- no --> B1
-        B6 -- yes --> B7["store centre_left / centre_right"]
+        B4 --> B5["slope & distance → classify left or right"]
+        B5 --> B6{"better than previous ?"}
+        B6 -- no  --> B1
+        B6 -- yes --> B7["store center_left and center_right"]
         B7 --> B1
-        B1 --> B8{"found at least one lane?"}
-        B8 -- no --> Z
-        B8 -- yes --> B9["return left/right pts & y_ref"]
+        B1 --> B8{"found at least one lane ?"}
+        B8 -- no  --> Z
+        B8 -- yes --> B9["return left / right points and y_ref"]
     end
 
-    %% ====== calculateTrackCenter DETAILS ======
-    subgraph C_details  ["Inside calculateTrackCenter()"]
-        C1{"both lanes present?"}
-        C1 -- yes --> C2["fitLine (left) & fitLine (right)"]
-        C2 --> C3["x_left / x_right @ y_ref"]
-        C3 --> C7["centre = (xL+xR)/2"]
-        C1 -- only right --> C4["x_right @ y_ref"]
-        C4 --> C5["centre = xR − disp_cm/scale"]
-        C1 -- only left --> C6["x_left @ y_ref"]
+    %% ===== calculateTrackCenter DETAILS =====
+    subgraph C_details ["Inside calculateTrackCenter()"]
+        C1{"both lanes present ?"}
+        C1 -- yes        --> C2["fitLine(left) and fitLine(right)"]
+        C2 --> C3["x_left and x_right at y_ref"]
+        C3 --> C7["center = (xL + xR) / 2"]
+        C1 -- only right --> C4["x_right at y_ref"]
+        C4 --> C5["center = xR minus disp_cm / scale"]
+        C1 -- only left  --> C6["x_left at y_ref"]
         C6 --> C5
         C5 --> C7
-        C7 --> C8["draw circles  ●"]
+        C7 --> C8["draw circles"]
         C8 --> E
     end
 ```

--- a/pid_control/docs/docs_hardware_module.md
+++ b/pid_control/docs/docs_hardware_module.md
@@ -44,7 +44,7 @@ graph TD
 graph TD
     A["read_byte(reg)"] --> B["write(fd_, &reg, 1)"]
     B -->|!=1| C["throw runtime_error"]
-    B["write(fd_, `&reg`, 1)"]
+    B["write(fd_, &amp;reg, 1)"]
     D -->|!=1| E["throw runtime_error"]
     D --> F["return value"]
 ```

--- a/pid_control/docs/docs_hardware_module.md
+++ b/pid_control/docs/docs_hardware_module.md
@@ -44,7 +44,7 @@ graph TD
 graph TD
     A["read_byte(reg)"] --> B["write(fd_, &reg, 1)"]
     B -->|!=1| C["throw runtime_error"]
-    B --> D["read(fd_, &value, 1)"]
+    B["write(fd_, `&reg`, 1)"]
     D -->|!=1| E["throw runtime_error"]
     D --> F["return value"]
 ```

--- a/pid_control/docs/docs_mermaid_guidelines.md
+++ b/pid_control/docs/docs_mermaid_guidelines.md
@@ -1,0 +1,100 @@
+# Mermaid Guidelines (ASCII-safe)
+
+This document shows clear, portable, and consistent rules for writing Mermaid.js diagrams in Markdown files for this project.
+
+---
+
+## Basic Rules
+
+1. **ASCII-safe only**
+
+   * Avoid symbols like `≥`, `→`, `×`, `÷`, `±`, `®`, `…`, etc.
+   * Use only ASCII characters for maximum compatibility across terminals and GitHub.
+
+2. **Text Style**
+
+   * Use lowercase for code terms: `center_x`, `y_ref`
+   * Use `and` instead of slashes (`/`) when meaning conjunction
+   * Use `or` when describing options, never `/`
+
+3. **Operators**
+
+   * Replace:
+
+     | Unicode | ASCII-safe        |
+     | ------- | ----------------- |
+     | `≥`     | `>=`              |
+     | `≤`     | `<=`              |
+     | `→`     | `->`              |
+     | `×`     | `*` or `x`        |
+     | `÷`     | `/`               |
+     | `±`     | `+/-`             |
+     | `…`     | `...`             |
+     | `®`     | `&reg;` (escaped) |
+
+4. **Node Names**
+
+   * Use short **IDs**: `A`, `B1`, `C_details`, etc.
+   * Place full description in **quotes**:
+
+     ```mermaid
+     A["Binary mask"] --> B["extractLanePoints"]
+     ```
+   * Avoid `/`, `:`, and `&` in node IDs (they can cause Mermaid or HTML parsing errors).
+
+5. **Subgraphs**
+
+   * Use for grouping logical blocks like functions:
+
+     ```mermaid
+     subgraph A_details ["Inside Function A"]
+     ...
+     end
+     ```
+
+6. **Arrows and Labels**
+
+   * Use `-->` for normal flow
+   * Use `-- yes -->`, `-- no -->` for conditions
+   * Use `-.->` for optional/dashed links
+
+7. **Escaping HTML (if needed)**
+   Use HTML entities:
+
+   | Symbol | Entity   |
+   | ------ | -------- |
+   | `&`    | `&amp;`  |
+   | `<`    | `&lt;`   |
+   | `>`    | `&gt;`   |
+   | `"`    | `&quot;` |
+
+   Especially when text like `&reg;`, `&value` appear in labels.
+
+8. **Use `<br/>` for multi-line nodes**
+
+   ```mermaid
+   A["Line 1<br/>Line 2"]
+   ```
+
+9. **Avoid math syntax unless escaped**
+   GitHub may misinterpret `/`, `*`, or brackets.
+
+   * Prefer: `x_left at y_ref` instead of `x_left(y_ref)`
+   * Use: `average(xL, xR)` or `center = (xL + xR) / 2`
+
+10. **Use Mermaid Live Editor to validate**
+
+* [https://mermaid.live](https://mermaid.live)
+
+---
+
+## Example
+
+```mermaid
+graph TD
+    A["Start"] --> B["Process"]
+    B -->|yes| C["End"]
+    B -->|no| A
+```
+
+---


### PR DESCRIPTION
In the docs_hardware_modules.md file, the string &reg inside the label was interpreted by HTML as the entity &amp;reg;, generating the symbol ®. I replaced it with &amp;reg to prevent the conversion.
I verified similar occurrences and implemented improvements.